### PR TITLE
Better configuration api for python

### DIFF
--- a/dist/py/src/codemp/codemp.pyi
+++ b/dist/py/src/codemp/codemp.pyi
@@ -7,7 +7,6 @@ class Driver:
 	"""
 	def stop(self) -> None: ...
 
-def get_default_config() -> Config: ...
 class Config:
 	"""
 	Configuration data structure for codemp clients
@@ -17,6 +16,8 @@ class Config:
 	host: Optional[str]
 	port: Optional[int]
 	tls: Optional[bool]
+
+	def __new__(cls, *, username: str, password: str, **kwargs) -> Config: ...
 
 def init() -> Driver: ...
 def set_logger(logger_cb: Callable[[str], None], debug: bool) -> bool: ...


### PR DESCRIPTION
Now python instead of the ugly `get_default_config()` can just call
`codemp.Config` constructor.
username and password are REQUIRED key word arguments, all the rest are optional.

examples:
```python
codemp.Config(username="...", password="...") #default
codemp.Config("...", "...") # error, no positional arguments allowed.
conf = {'username': "...", 'password': "...", 'host': "..." }
codemp.Config(**conf) # works, pass in a whole dictionary
```
unknown keywords are ignored.
known keywords with wrong format (i.e. `port = "10"`) are ignored.