### PR TITLE
fix: lua macos build

### DIFF
--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -20,19 +20,16 @@ jobs:
             target: linux-gnu
             pre: lib
             ext: so
-            buildcmd: cargo build --release --features=luajit
           - runner: windows-latest
             arch: x86_64
             target: windows-msvc
             pre:
             ext: dll
-            buildcmd: cargo build --release --features=luajit
           - runner: macos-latest
             arch: aarch64
             target: darwin
             pre: lib
             ext: dylib
-            buildcmd: cargo rustc --release --features=luajit -- -C link-arg=-undefined -C link-arg=dynamic_lookup
     steps:
       - uses: actions/checkout@v4
         with:
@@ -41,7 +38,7 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: ${{ matrix.platform.buildcmd }}
+      - run: cargo build --release --features=luajit
       - id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,9 @@
 name: test
 
 on:
-  push:
-    branches:
-      - dev
+  push
   pull_request:
-    types: [review_requested, synchronize]
+    types: [synchronize, review_requested]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,38 +27,6 @@ jobs:
           - java
           - js
           - py
-        toolchain:
-          - stable
-          - beta
-          - nightly
-    steps:
-      - uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.toolchain }}
-      - run: cargo build --release --verbose --features=${{ matrix.features }}
-
-  # TODO to build lua bindings on macos, we need to tweak the compile command to expose symbols
-  #      since i can't add conditional steps to above task, i have to separate off lua from the rest...
-  build-lua:
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - runner: ubuntu-latest
-            action: build
-            extra:
-          - runner: windows-latest
-            action: build
-            extra:
-          - runner: macos-latest
-            action: rustc
-            extra: -- -C link-arg=-undefined -C link-arg=dynamic_lookup
-        features:
           - luajit
           - lua54
         toolchain:
@@ -73,17 +41,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-      - run: cargo ${{ matrix.platform.action }} --release --verbose --features=${{ matrix.features }} ${{ matrix.platform.extra }}
+      - run: cargo build --release --verbose --features=${{ matrix.features }}
 
   test:
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        runner:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
         toolchain:
           - stable
           - beta

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: test
 
 on:
-  push
+  push:
   pull_request:
     types: [synchronize, review_requested]
 

--- a/build.rs
+++ b/build.rs
@@ -15,4 +15,12 @@ fn main() {
 	{
 		pyo3_build_config::add_extension_module_link_args();
 	}
+
+	#[cfg(feature = "lua")]
+	{
+		if let Ok("macos") = std::env::var("CARGO_CFG_TARGET_OS").as_deref() {
+			println!("cargo:rustc-cdylib-link-arg=-undefined");
+  		println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+  	}
+	}
 }


### PR DESCRIPTION
TIL that cmdline args can be passed via `build.rs` as simple `println!()`, definitely using this for Lua macos args (and turns out `napi` is doing the same for js args, probs pyo3 too)