### PR TITLE
feat(lua): cancel promise

### DIFF
--- a/dist/lua/annotations.lua
+++ b/dist/lua/annotations.lua
@@ -18,6 +18,9 @@ local NilPromise = {}
 --- block until promise is ready
 function NilPromise:await() end
 
+--- cancel promise execution
+function NilPromise:abort() end
+
 ---@param cb fun() callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function NilPromise:and_then(cb) end
@@ -30,6 +33,9 @@ local StringPromise = {}
 --- @return string
 function StringPromise:await() end
 
+--- cancel promise execution
+function StringPromise:abort() end
+
 ---@param cb fun(x: string) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function StringPromise:and_then(cb) end
@@ -40,6 +46,8 @@ local StringArrayPromise = {}
 --- block until promise is ready and return value
 --- @return string[]
 function StringArrayPromise:await() end
+--- cancel promise execution
+function StringArrayPromise:abort() end
 ---@param cb fun(x: string[]) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function StringArrayPromise:and_then(cb) end
@@ -50,6 +58,8 @@ local ClientPromise = {}
 --- block until promise is ready and return value
 --- @return Client
 function ClientPromise:await() end
+--- cancel promise execution
+function ClientPromise:abort() end
 ---@param cb fun(x: Client) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function ClientPromise:and_then(cb) end
@@ -60,6 +70,8 @@ local WorkspacePromise = {}
 --- block until promise is ready and return value
 --- @return Workspace
 function WorkspacePromise:await() end
+--- cancel promise execution
+function WorkspacePromise:abort() end
 ---@param cb fun(x: Workspace) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function WorkspacePromise:and_then(cb) end
@@ -70,6 +82,8 @@ local WorkspaceEventPromise = {}
 --- block until promise is ready and return value
 --- @return WorkspaceEvent
 function WorkspaceEventPromise:await() end
+--- cancel promise execution
+function WorkspaceEventPromise:abort() end
 ---@param cb fun(x: WorkspaceEvent) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function WorkspaceEventPromise:and_then(cb) end
@@ -80,6 +94,8 @@ local BufferControllerPromise = {}
 --- block until promise is ready and return value
 --- @return BufferController
 function BufferControllerPromise:await() end
+--- cancel promise execution
+function BufferControllerPromise:abort() end
 ---@param cb fun(x: BufferController) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function BufferControllerPromise:and_then(cb) end
@@ -90,6 +106,8 @@ local CursorPromise = {}
 --- block until promise is ready and return value
 --- @return Cursor
 function CursorPromise:await() end
+--- cancel promise execution
+function CursorPromise:abort() end
 ---@param cb fun(x: Cursor) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function CursorPromise:and_then(cb) end
@@ -100,6 +118,8 @@ local MaybeCursorPromise = {}
 --- block until promise is ready and return value
 --- @return Cursor | nil
 function MaybeCursorPromise:await() end
+--- cancel promise execution
+function MaybeCursorPromise:abort() end
 ---@param cb fun(x: Cursor | nil) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function MaybeCursorPromise:and_then(cb) end
@@ -110,6 +130,8 @@ local TextChangePromise = {}
 --- block until promise is ready and return value
 --- @return TextChange
 function TextChangePromise:await() end
+--- cancel promise execution
+function TextChangePromise:abort() end
 ---@param cb fun(x: TextChange) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function TextChangePromise:and_then(cb) end
@@ -120,6 +142,8 @@ local MaybeTextChangePromise = {}
 --- block until promise is ready and return value
 --- @return TextChange | nil
 function MaybeTextChangePromise:await() end
+--- cancel promise execution
+function MaybeTextChangePromise:abort() end
 ---@param cb fun(x: TextChange | nil) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function MaybeTextChangePromise:and_then(cb) end

--- a/dist/lua/annotations.lua
+++ b/dist/lua/annotations.lua
@@ -19,7 +19,7 @@ local NilPromise = {}
 function NilPromise:await() end
 
 --- cancel promise execution
-function NilPromise:abort() end
+function NilPromise:cancel() end
 
 ---@param cb fun() callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
@@ -34,7 +34,7 @@ local StringPromise = {}
 function StringPromise:await() end
 
 --- cancel promise execution
-function StringPromise:abort() end
+function StringPromise:cancel() end
 
 ---@param cb fun(x: string) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
@@ -47,7 +47,7 @@ local StringArrayPromise = {}
 --- @return string[]
 function StringArrayPromise:await() end
 --- cancel promise execution
-function StringArrayPromise:abort() end
+function StringArrayPromise:cancel() end
 ---@param cb fun(x: string[]) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function StringArrayPromise:and_then(cb) end
@@ -59,7 +59,7 @@ local ClientPromise = {}
 --- @return Client
 function ClientPromise:await() end
 --- cancel promise execution
-function ClientPromise:abort() end
+function ClientPromise:cancel() end
 ---@param cb fun(x: Client) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function ClientPromise:and_then(cb) end
@@ -71,7 +71,7 @@ local WorkspacePromise = {}
 --- @return Workspace
 function WorkspacePromise:await() end
 --- cancel promise execution
-function WorkspacePromise:abort() end
+function WorkspacePromise:cancel() end
 ---@param cb fun(x: Workspace) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function WorkspacePromise:and_then(cb) end
@@ -83,7 +83,7 @@ local WorkspaceEventPromise = {}
 --- @return WorkspaceEvent
 function WorkspaceEventPromise:await() end
 --- cancel promise execution
-function WorkspaceEventPromise:abort() end
+function WorkspaceEventPromise:cancel() end
 ---@param cb fun(x: WorkspaceEvent) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function WorkspaceEventPromise:and_then(cb) end
@@ -95,7 +95,7 @@ local BufferControllerPromise = {}
 --- @return BufferController
 function BufferControllerPromise:await() end
 --- cancel promise execution
-function BufferControllerPromise:abort() end
+function BufferControllerPromise:cancel() end
 ---@param cb fun(x: BufferController) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function BufferControllerPromise:and_then(cb) end
@@ -107,7 +107,7 @@ local CursorPromise = {}
 --- @return Cursor
 function CursorPromise:await() end
 --- cancel promise execution
-function CursorPromise:abort() end
+function CursorPromise:cancel() end
 ---@param cb fun(x: Cursor) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function CursorPromise:and_then(cb) end
@@ -119,7 +119,7 @@ local MaybeCursorPromise = {}
 --- @return Cursor | nil
 function MaybeCursorPromise:await() end
 --- cancel promise execution
-function MaybeCursorPromise:abort() end
+function MaybeCursorPromise:cancel() end
 ---@param cb fun(x: Cursor | nil) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function MaybeCursorPromise:and_then(cb) end
@@ -131,7 +131,7 @@ local TextChangePromise = {}
 --- @return TextChange
 function TextChangePromise:await() end
 --- cancel promise execution
-function TextChangePromise:abort() end
+function TextChangePromise:cancel() end
 ---@param cb fun(x: TextChange) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function TextChangePromise:and_then(cb) end
@@ -143,7 +143,7 @@ local MaybeTextChangePromise = {}
 --- @return TextChange | nil
 function MaybeTextChangePromise:await() end
 --- cancel promise execution
-function MaybeTextChangePromise:abort() end
+function MaybeTextChangePromise:cancel() end
 ---@param cb fun(x: TextChange | nil) callback to invoke
 ---invoke callback asynchronously as soon as promise is ready
 function MaybeTextChangePromise:and_then(cb) end

--- a/src/ffi/lua/ext/a_sync.rs
+++ b/src/ffi/lua/ext/a_sync.rs
@@ -51,7 +51,7 @@ impl LuaUserData for Promise {
 					.map_err(LuaError::runtime)?
 			},
 		});
-		methods.add_method_mut("abort", |_, this, ()| match this.0.take() {
+		methods.add_method_mut("cancel", |_, this, ()| match this.0.take() {
 			None => Err(LuaError::runtime("Promise already awaited")),
 			Some(x) => {
 				x.abort();

--- a/src/ffi/lua/ext/a_sync.rs
+++ b/src/ffi/lua/ext/a_sync.rs
@@ -51,6 +51,13 @@ impl LuaUserData for Promise {
 					.map_err(LuaError::runtime)?
 			},
 		});
+		methods.add_method_mut("abort", |_, this, ()| match this.0.take() {
+			None => Err(LuaError::runtime("Promise already awaited")),
+			Some(x) => {
+				x.abort();
+				Ok(())
+			},
+		});
 		methods.add_method_mut("and_then", |_, this, (cb,):(LuaFunction,)| match this.0.take() {
 			None => Err(LuaError::runtime("Promise already awaited")),
 			Some(x) => {


### PR DESCRIPTION
add a method on `Promise`s to cancel underlying async task. This is necessary to allow dropping references blocked in a never-unblocking .await, keeping stuff from being freed, but also generally to complete the Lua async API