### PR TITLE
fix: leave_workspace returns like detach

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -182,7 +182,10 @@ impl Client {
 
 	/// Leave the [`Workspace`] with the given name.
 	pub fn leave_workspace(&self, id: &str) -> bool {
-		self.0.workspaces.remove(id).is_some()
+		match self.0.workspaces.remove(id) {
+			None => true,
+			Some(x) => x.1.consume(),
+		}
 	}
 
 	/// Gets a [`Workspace`] handle by name.

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -100,6 +100,11 @@ impl Workspace {
 		Ok(ws)
 	}
 
+	/// drop arc, return true if was last
+	pub(crate) fn consume(self) -> bool {
+		Arc::into_inner(self.0).is_some()
+	}
+
 	/// Create a new buffer in the current workspace.
 	pub async fn create(&self, path: &str) -> RemoteResult<()> {
 		let mut workspace_client = self.0.services.ws();
@@ -312,6 +317,7 @@ impl Workspace {
 		let weak = Arc::downgrade(&self.0);
 		let name = self.id();
 		tokio::spawn(async move {
+			tracing::debug!("workspace worker starting");
 			loop {
 				// TODO can we stop responsively rather than poll for Arc being dropped?
 				if weak.upgrade().is_none() {
@@ -359,6 +365,7 @@ impl Workspace {
 					}
 				}
 			}
+			tracing::debug!("workspace worker stopping");
 		});
 	}
 }


### PR DESCRIPTION
previously only returned `true` if Client held a workspace reference, now it returns `true` if last ref has been dropped, or no ref was being owned. If, while dropping, dangling refs are still present, it will return `false` (just like detach method)